### PR TITLE
- wrong foundry install switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 
 setup:
-	@forge install OpenZeppelin/openzeppelin-contracts --no-commit
-	@forge install OpenZeppelin/openzeppelin-contracts-upgradeable --no-commit
-	@forge install foundry-rs/forge-std --no-commit
-	@forge install Cyfrin/foundry-devops --no-commit
+	@forge install OpenZeppelin/openzeppelin-contracts --no-git
+	@forge install OpenZeppelin/openzeppelin-contracts-upgradeable --no-git
+	@forge install foundry-rs/forge-std --no-git
+	@forge install Cyfrin/foundry-devops --no-git


### PR DESCRIPTION
# What ?

1. [`foundry install`](https://book.getfoundry.sh/reference/forge/forge-install) has no switch `--no-commit`  in `Makefile`

- The intention was to use `--no-git` 
- This PR reflects this change